### PR TITLE
Fix an error

### DIFF
--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -85,6 +85,9 @@ var restoreCmd = &cobra.Command{
 		}
 
 		file := saveCacheFileFromS3Item(dir, item)
+
+		defer file.Close()
+
 		extractCache(dir, file)
 		moveToOriginalPaths(dir)
 	},
@@ -148,8 +151,6 @@ func saveCacheFileFromS3Item(dir string, item *s3.GetObjectOutput) *os.File {
 	if err != nil {
 		log.Fatalf("failed to create cache file: %s", err)
 	}
-
-	defer file.Close()
 
 	if _, err := io.Copy(file, item.Body); err != nil {
 		log.Fatalf("failed to save cache file: %s", err)


### PR DESCRIPTION
This kind of error:

```
2019/01/12 21:40:33 failed to open gzip file: read /tmp/guruguru-cache-212370162/cache.tar.gz: file already closed
```